### PR TITLE
SO_REUSEPORT not supported on linux < 3.9

### DIFF
--- a/src/address_family.rs
+++ b/src/address_family.rs
@@ -14,7 +14,7 @@ pub trait AddressFamily {
         let builder = Self::socket_builder()?;
         builder.reuse_address(true)?;
         #[cfg(not(windows))]
-        builder.reuse_port(true)?;
+        let _ = builder.reuse_port(true);
         let socket = builder.bind(&addr)?;
         Self::join_multicast(&socket)?;
         Ok(socket)


### PR DESCRIPTION
Thanks for spotty!

Was asking myself why spotify connect with zeroconf on spotty does not work on my Synology DS-214 (with linux 3.2.40) within Logitech Media Server.

The error message code: 92, message: "Protocol not available" does hint to a problem with setsocketoption. 

There was a zeroconf client in python showing exactly the same problem which was fixed by ignoring the error code from linux system call.
See https://github.com/jstasiak/python-zeroconf/commit/023426e0f8982640f46bca3dfcd3abeee2cb832f

rust-mdns does the same call in the end as the python code.  (Is spotty actually compiled with this version?)

I do not know rust, but it seems that we have to ignore the result from builder.reuse_port(true).
https://stackoverflow.com/questions/51141672/how-do-i-ignore-an-error-returned-from-a-rust-function-and-proceed-regardless
So I proposing this fix, stitching all things together.
